### PR TITLE
Added additional Makefile commands for easier deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,35 @@
 run-api:
 	@echo "Starting FastAPI server..."
 	uvicorn photopocalypse.api.fast:app --host 0.0.0.0 --port 8080 --reload
+
+# Defining variables for convenience
+IMAGE_NAME=phurge-image
+INTEL_IMAGE_TAG=$(IMAGE_NAME):intel
+PROD_IMAGE_TAG=$(IMAGE_NAME):prod
+
+# Default target
+all: build-prod build-intel tag push deploy
+
+# Build the production Docker image
+build-prod:
+	docker build -t $(PROD_IMAGE_TAG) .
+
+# Build the Intel architecture Docker image
+build-intel:
+	docker build --platform linux/amd64 -t phurge:intel .
+
+# Tag the Intel image
+tag:
+	docker tag phurge:intel $(INTEL_IMAGE_TAG)
+
+# Push the Intel image to the registry
+push:
+	docker push $(INTEL_IMAGE_TAG)
+
+# Deploy the Intel image using gcloud
+deploy:
+	gcloud run deploy --image $(INTEL_IMAGE_TAG) --memory 2Gi --region europe-west1
+
+# Helper target to clean up local images
+clean:
+	docker rmi $(PROD_IMAGE_TAG) phurge:intel $(INTEL_IMAGE_TAG)


### PR DESCRIPTION
## Pull Request: Enhanced Makefile for Improved Docker and Cloud Run Workflow

This PR introduces significant updates to the `Makefile` to streamline the Docker build and deployment process for our FastAPI server. Key enhancements include:

- Added comprehensive Docker build commands for both production and Intel architecture-specific images.
- Implemented tagging and pushing of built images to a Docker registry.
- Automated deployment of the Intel architecture image to Google Cloud Run with specified memory and region settings.
- Introduced a `clean` command for easy local Docker image cleanup.

The update aims to improve the efficiency and clarity of our deployment workflow, ensuring a more robust and maintainable build process.

**Changes:**
32 additions & 0 deletions in `Makefile`
